### PR TITLE
Add view mode

### DIFF
--- a/typescript/packages/nestjs/.search-and-discovery/config/Example.1.0.0.json
+++ b/typescript/packages/nestjs/.search-and-discovery/config/Example.1.0.0.json
@@ -16,7 +16,12 @@
       },
       {
         "type": "layout-row",
-        "rows": []
+        "rows": [
+          {
+            "description": "",
+            "type": "widget"
+          }
+        ]
       }
     ],
     "type": "layout-row"

--- a/typescript/packages/nextjs/src/components/ViewDashboard.tsx
+++ b/typescript/packages/nextjs/src/components/ViewDashboard.tsx
@@ -8,7 +8,8 @@ import { EditOutlined, EyeOutlined, LeftOutlined } from "@ant-design/icons";
 import { Button, Flex } from "antd";
 import type { Block as BlockType } from "api";
 import styles from "./ViewDashboard.module.scss";
-import { Block } from "./layout/Block";
+import { EditBlock } from "./layout/EditBlock";
+import { ViewBlock } from "./layout/ViewBlock";
 
 export const ViewDashboard = () => {
 	const dispatch = useAppDispatch();
@@ -68,11 +69,15 @@ export const ViewDashboard = () => {
 					</Button>
 				</Flex>
 			</Flex>
-			<Block
-				block={viewingDashboard.file.entryBlock}
-				isRoot
-				onUpdate={updateDashboard}
-			/>
+			{displayState === "edit" ? (
+				<EditBlock
+					block={viewingDashboard.file.entryBlock}
+					isRoot
+					onUpdate={updateDashboard}
+				/>
+			) : (
+				<ViewBlock block={viewingDashboard.file.entryBlock} />
+			)}
 		</Flex>
 	);
 };

--- a/typescript/packages/nextjs/src/components/layout/EditBlock.module.scss
+++ b/typescript/packages/nextjs/src/components/layout/EditBlock.module.scss
@@ -36,6 +36,8 @@
 
     display: flex;
     flex: 1;
+    background: vars.$white;
+    color: vars.$muted-text;
 }
 
 .delete {

--- a/typescript/packages/nextjs/src/components/layout/EditBlock.tsx
+++ b/typescript/packages/nextjs/src/components/layout/EditBlock.tsx
@@ -11,7 +11,7 @@ import { Button, Flex } from "antd";
 import type { Block as BlockType } from "api";
 import clsx from "clsx";
 import { useState } from "react";
-import styles from "./Block.module.scss";
+import styles from "./EditBlock.module.scss";
 
 const AddBlock = ({
 	onAdd,
@@ -44,7 +44,7 @@ const AddBlock = ({
 	);
 };
 
-export const Block = ({
+export const EditBlock = ({
 	block,
 	isRoot = false,
 	onUpdate,
@@ -145,7 +145,7 @@ export const Block = ({
 				{maybeRenderDelete()}
 				<div className={styles.rowContainer}>
 					{block.rows.map((row, index) => (
-						<Block
+						<EditBlock
 							block={row}
 							key={`row-${index}`}
 							onDelete={onDeleteRow(index)}
@@ -196,7 +196,7 @@ export const Block = ({
 				{maybeRenderDelete()}
 				<div className={styles.columnContainer}>
 					{block.columns.map((column, index) => (
-						<Block
+						<EditBlock
 							block={column}
 							key={`column-${index}`}
 							onDelete={onDeleteColumn(index)}

--- a/typescript/packages/nextjs/src/components/layout/ViewBlock.module.scss
+++ b/typescript/packages/nextjs/src/components/layout/ViewBlock.module.scss
@@ -1,0 +1,27 @@
+@use "@/style/variables" as vars;
+
+%block {
+    display: flex;
+    flex: 1;
+}
+
+.layoutRows {
+    @extend %block;
+    flex-direction: column
+}
+
+.layoutColumns {
+    @extend %block;
+}
+
+.widget {
+    @extend %block;
+
+    justify-content: center;
+    align-items: center;
+    border: 1px solid vars.$black;
+    border-radius: 6px;
+    margin: 10px;
+    background: vars.$white;
+    color: vars.$muted-text;
+}

--- a/typescript/packages/nextjs/src/components/layout/ViewBlock.tsx
+++ b/typescript/packages/nextjs/src/components/layout/ViewBlock.tsx
@@ -1,0 +1,26 @@
+import type { Block } from "api";
+import styles from "./ViewBlock.module.scss";
+
+export const ViewBlock = ({ block }: { block: Block }) => {
+	if (block.type === "layout-row") {
+		return (
+			<div className={styles.layoutRows}>
+				{block.rows.map((c, index) => (
+					<ViewBlock block={c} key={`column-${index}`} />
+				))}
+			</div>
+		);
+	}
+
+    if (block.type === "layout-column") {
+		return (
+			<div className={styles.layoutColumns}>
+				{block.columns.map((c, index) => (
+					<ViewBlock block={c} key={`column-${index}`} />
+				))}
+			</div>
+		);
+	}
+
+	return <div className={styles.widget}>Widget here</div>;
+};


### PR DESCRIPTION
This pull request includes several changes to the `typescript/packages/nextjs` and `typescript/packages/nestjs` projects, focusing on improving the layout and organization of components, as well as updating the configuration files. The most important changes include renaming and refactoring components, updating styles, and modifying the configuration for layout rows.

### Component Refactoring and Renaming:

* [`typescript/packages/nextjs/src/components/ViewDashboard.tsx`](diffhunk://#diff-674497f1ed63332fab7cf0fb192486f0d7d8fbaa63df795ee2139cb66f6aab39L11-R12): Updated imports to use `EditBlock` and `ViewBlock` instead of `Block`, and modified the `ViewDashboard` component to conditionally render `EditBlock` or `ViewBlock` based on the `displayState`. [[1]](diffhunk://#diff-674497f1ed63332fab7cf0fb192486f0d7d8fbaa63df795ee2139cb66f6aab39L11-R12) [[2]](diffhunk://#diff-674497f1ed63332fab7cf0fb192486f0d7d8fbaa63df795ee2139cb66f6aab39L71-R80)
* [`typescript/packages/nextjs/src/components/layout/EditBlock.tsx`](diffhunk://#diff-da71ed42128a86b5d40bfae9782119f13cb15f8b7798f7e9413cbd5b12f4d1cfL14-R14): Renamed from `Block.tsx` to `EditBlock.tsx`, and updated the component to use `EditBlock` instead of `Block` for nested blocks. [[1]](diffhunk://#diff-da71ed42128a86b5d40bfae9782119f13cb15f8b7798f7e9413cbd5b12f4d1cfL14-R14) [[2]](diffhunk://#diff-da71ed42128a86b5d40bfae9782119f13cb15f8b7798f7e9413cbd5b12f4d1cfL47-R47) [[3]](diffhunk://#diff-da71ed42128a86b5d40bfae9782119f13cb15f8b7798f7e9413cbd5b12f4d1cfL148-R148) [[4]](diffhunk://#diff-da71ed42128a86b5d40bfae9782119f13cb15f8b7798f7e9413cbd5b12f4d1cfL199-R199)
* [`typescript/packages/nextjs/src/components/layout/ViewBlock.tsx`](diffhunk://#diff-af720581a9f930d99c589db65db8e292333126e6596c6627fe891aa0d7a4d97eR1-R26): Added a new `ViewBlock` component to handle the display of layout rows, columns, and widgets.

### Style Updates:

* [`typescript/packages/nextjs/src/components/layout/EditBlock.module.scss`](diffhunk://#diff-bec3e281b29f1852d64b62532b6f4cc4294280badd0a1e9a8a0cab5ce7adf541R39-R40): Renamed from `Block.module.scss` to `EditBlock.module.scss`, and added new styles for `EditBlock`.
* [`typescript/packages/nextjs/src/components/layout/ViewBlock.module.scss`](diffhunk://#diff-8ccc5e98664ae17a1ae25872025f2438d860d9aa4993a0698e1f9a178ab010ccR1-R27): Added new styles for the `ViewBlock` component, including layout rows, columns, and widgets.

### Configuration Updates:

* [`typescript/packages/nestjs/.search-and-discovery/config/Example.1.0.0.json`](diffhunk://#diff-0a5309ed52d100241b04cc10dd4125eb3a9799310890854b81868780ff7ed897L19-R24): Modified the configuration to add a widget to the layout rows.