### PR TITLE
Allow renaming the dashboard

### DIFF
--- a/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
+++ b/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
@@ -1,0 +1,12 @@
+{
+  "entryBlock": {
+    "rows": [
+      {
+        "type": "widget",
+        "description": "Example widget description"
+      }
+    ],
+    "type": "layout-row"
+  },
+  "version": "1.0.0"
+}

--- a/typescript/packages/nestjs/src/app.controller.ts
+++ b/typescript/packages/nestjs/src/app.controller.ts
@@ -14,8 +14,16 @@ export class AppController {
 
 	@Post("update-config")
 	updateConfig(@Body() config: SearchAndDiscoverConfigWithName) {
-		console.log(config, "@@@@@@@");
-
 		return this.appService.updateConfig(config.name, config.file);
+	}
+
+	@Post("new-config")
+	newConfig() {
+		return this.appService.createNewConfig();
+	}
+
+	@Post("rename-config")
+	renameConfig(@Body() config: { old: SearchAndDiscoverConfigWithName; new: SearchAndDiscoverConfigWithName }) {
+		return this.appService.renameConfig(config.old, config.new);
 	}
 }

--- a/typescript/packages/nestjs/src/app.service.ts
+++ b/typescript/packages/nestjs/src/app.service.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Injectable } from "@nestjs/common";
-import type { SearchAndDiscoverConfig, SearchAndDiscoverConfigs } from "api";
+import type { SearchAndDiscoverConfig, SearchAndDiscoverConfigWithName, SearchAndDiscoverConfigs } from "api";
 // biome-ignore lint/style/useImportType: <explanation>
 import { ConfigService } from "./config.service";
 
@@ -22,6 +22,17 @@ export class AppService {
 		}
 
 		this.configService.updateConfig(configName, config);
+		return { status: "ok" };
+	}
+
+	public createNewConfig(): SearchAndDiscoverConfigWithName {
+		return this.configService.createNewDashboard();
+	}
+
+	public renameConfig(old: SearchAndDiscoverConfigWithName, newConfig: SearchAndDiscoverConfigWithName) {
+		this.configService.deleteConfig(old.name);
+		this.updateConfig(newConfig.name, newConfig.file);
+
 		return { status: "ok" };
 	}
 }

--- a/typescript/packages/nestjs/src/config.service.ts
+++ b/typescript/packages/nestjs/src/config.service.ts
@@ -3,6 +3,7 @@ import {
 	mkdirSync,
 	readFileSync,
 	readdirSync,
+	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
@@ -54,13 +55,38 @@ export class ConfigService {
 		);
 	}
 
+	public createNewDashboard(): SearchAndDiscoverConfigWithName {
+		const allFiles = readdirSync(this.configDirectory);
+		const latestExample = allFiles
+			.filter((file) => file.toLowerCase().startsWith("example"))
+			.map((file) => file.match(/\d+/g))
+			.map((match) => (match ? Number.parseInt(match[0]) : 0))
+			.sort((a, b) => b - a)[0];
+		
+		const newFileName = `Example-${(latestExample ?? 0) + 1}`;
+		const exampleConfig = this.createExampleConfig();
+	
+		this.updateConfig(newFileName, exampleConfig);
+
+		return {
+			name: newFileName,
+			file: exampleConfig
+		}
+	}
+
+	public deleteConfig(fileName: string) {
+		return unlinkSync(this.getFullPath(fileName));
+	}
+
 	private createExampleConfig(): SearchAndDiscoverConfig {
 		return {
 			entryBlock: {
-				rows: [{
-					type: "widget",
-					description: "Example widget description",
-				}],
+				rows: [
+					{
+						type: "widget",
+						description: "Example widget description",
+					},
+				],
 				type: "layout-row",
 			},
 			version: "1.0.0",

--- a/typescript/packages/nextjs/src/components/SelectDashboard.tsx
+++ b/typescript/packages/nextjs/src/components/SelectDashboard.tsx
@@ -1,4 +1,5 @@
 import { useGetConfigs } from "@/lib/hooks/useGetConfigs";
+import { configService } from "@/lib/services/configService";
 import { useAppDispatch, useAppSelector } from "@/lib/store/Provider";
 import { setViewingDashboard } from "@/lib/store/dashboard/dashboard";
 import { Button, Flex } from "antd";
@@ -38,6 +39,11 @@ export const SelectDashboard = () => {
 		dispatch(setViewingDashboard(config));
 	};
 
+	const createNewDashboard = async () => {
+		const newConfig = await configService.createNewConfig();
+		dispatch(setViewingDashboard(newConfig));
+	}
+
 	return (
 		<Flex vertical flex={1}>
 			<Flex className={styles.title} justify="center">
@@ -58,7 +64,7 @@ export const SelectDashboard = () => {
 				))}
 			</Flex>
 			<Flex className={styles.newDashboard} align="center" justify="center">
-				<Button>New dashboard</Button>
+				<Button onClick={createNewDashboard}>New dashboard</Button>
 			</Flex>
 		</Flex>
 	);

--- a/typescript/packages/nextjs/src/components/ViewDashboard.tsx
+++ b/typescript/packages/nextjs/src/components/ViewDashboard.tsx
@@ -8,6 +8,7 @@ import { EditOutlined, EyeOutlined, LeftOutlined } from "@ant-design/icons";
 import { Button, Flex } from "antd";
 import type { Block as BlockType } from "api";
 import styles from "./ViewDashboard.module.scss";
+import { DashboardName } from "./edit/DashboardName";
 import { EditBlock } from "./layout/EditBlock";
 import { ViewBlock } from "./layout/ViewBlock";
 
@@ -45,11 +46,12 @@ export const ViewDashboard = () => {
 	return (
 		<Flex className={styles.mainContainer} vertical flex={1} gap={10}>
 			<Flex align="center" justify="space-between">
-				<Flex>
+				<Flex align="center" gap={20}>
 					<Button onClick={goBackToSelect}>
 						<LeftOutlined />
 						Back
 					</Button>
+					<DashboardName />
 				</Flex>
 				<Flex>
 					<Button

--- a/typescript/packages/nextjs/src/components/edit/DashboardName.module.scss
+++ b/typescript/packages/nextjs/src/components/edit/DashboardName.module.scss
@@ -1,0 +1,12 @@
+@use "@/style/variables" as vars;
+
+.dashboardName {
+    font-size: 25px;
+    font-weight: 500;
+}
+
+.input {
+    display: flex;
+    flex: 1;
+    width: 350px;
+}

--- a/typescript/packages/nextjs/src/components/edit/DashboardName.tsx
+++ b/typescript/packages/nextjs/src/components/edit/DashboardName.tsx
@@ -1,0 +1,37 @@
+import { configService } from "@/lib/services/configService";
+import { useAppDispatch, useAppSelector } from "@/lib/store/Provider";
+import { setViewingDashboard } from "@/lib/store/dashboard/dashboard";
+import { Flex, Input } from "antd";
+import { useEffect, useState } from "react";
+import styles from "./DashboardName.module.scss";
+
+export const DashboardName = () => {
+    const dispatch = useAppDispatch();
+    const { viewingDashboard, displayState } = useAppSelector((s) => s.dashboard);
+
+    const [dashboardName, setDashboardName] = useState("");
+
+    useEffect(() => {
+        setDashboardName(viewingDashboard?.name ?? "");
+    }, [viewingDashboard]);
+
+    if (viewingDashboard === undefined) {
+        return;
+    }
+
+    if (displayState === "view") {
+        return <Flex className={styles.dashboardName}>{viewingDashboard.name}</Flex>
+    }
+
+    const updateDashboardName = async () => {
+        const oldConfig = { ...viewingDashboard };
+        const newConfig = { ...viewingDashboard, name: dashboardName };
+
+        await configService.renameConfig(oldConfig, newConfig);
+        dispatch(setViewingDashboard(newConfig));
+    }
+
+    return (
+        <Input className={styles.input} value={dashboardName} onChange={(e) => setDashboardName(e.target.value)} onBlur={updateDashboardName} />
+    )
+}

--- a/typescript/packages/nextjs/src/lib/services/configService.ts
+++ b/typescript/packages/nextjs/src/lib/services/configService.ts
@@ -3,7 +3,11 @@ import type { SearchAndDiscoverConfigWithName, SearchAndDiscoverConfigs } from "
 // Keep this in sync with app.controller.ts in nestjs
 class ConfigService {
 	public async getConfigs(): Promise<SearchAndDiscoverConfigs> {
-		const rawResponse = await fetch("http://localhost:3001/app/get-configs");
+		const rawResponse = await fetch("http://localhost:3001/app/get-configs", {
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
 		const allFiles = await rawResponse.json();
 
 		return allFiles;
@@ -18,7 +22,31 @@ class ConfigService {
 			body: JSON.stringify(config),
 		});
 
-		return rawResponse;
+		return rawResponse.json();
+	}
+
+	public async createNewConfig(): Promise<SearchAndDiscoverConfigWithName> {
+		const rawResponse = await fetch("http://localhost:3001/app/new-config", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+		const newConfig = await rawResponse.json();
+
+		return newConfig;
+	}
+
+	public async renameConfig(old: SearchAndDiscoverConfigWithName, newConfig: SearchAndDiscoverConfigWithName) {
+		const rawResponse = await fetch("http://localhost:3001/app/rename-config", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ old, new: newConfig }),
+		});
+
+		return rawResponse.json();
 	}
 }
 


### PR DESCRIPTION
<img width="588" alt="image" src="https://github.com/user-attachments/assets/d2fae1cb-923a-436e-804f-f38ebcc79dae" />

This pull request introduces several new features and improvements to the dashboard configuration functionality in the `nestjs` and `nextjs` packages. The changes include adding new endpoints for creating and renaming configurations, updating the service layer to support these operations, and enhancing the UI components to integrate the new functionality.

### New features and improvements:

* **API Endpoints:**
  - Added new endpoints in `AppController` for creating and renaming configurations (`newConfig` and `renameConfig`).
  - Updated `AppService` to include methods for creating a new configuration and renaming an existing one.

* **Service Layer:**
  - Enhanced `ConfigService` to support creating new dashboards and deleting configurations.
  - Updated `configService` in `nextjs` to include methods for creating and renaming configurations.

* **UI Components:**
  - Modified `SelectDashboard` component to handle the creation of new dashboards.
  - Added `DashboardName` component to display and edit the name of the current dashboard.

* **Styling:**
  - Added new styles for the `DashboardName` component.

### Other changes:

* **Configuration File:**
  - Added a new JSON configuration file for an example dashboard.

These changes collectively enhance the functionality and user experience of the dashboard configuration system.