### PR TITLE
Allow configuring python files and checking for correctness

### DIFF
--- a/typescript/packages/nestjs/.search-and-discovery/config/Example.1.0.0.json
+++ b/typescript/packages/nestjs/.search-and-discovery/config/Example.1.0.0.json
@@ -6,11 +6,13 @@
         "rows": [
           {
             "description": "",
-            "type": "widget"
+            "type": "widget",
+            "dataScript": "return 1+1"
           },
           {
             "description": "",
-            "type": "widget"
+            "type": "widget",
+            "dataScript": "return 1+1"
           }
         ]
       },

--- a/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
+++ b/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
@@ -5,6 +5,26 @@
         "type": "widget",
         "dataScript": "print(\"Hello world!!!!!\")\nreturn 1+1",
         "description": "Example widget description"
+      },
+      {
+        "type": "layout-row",
+        "rows": [
+          {
+            "description": "",
+            "dataScript": "",
+            "type": "widget"
+          }
+        ]
+      },
+      {
+        "type": "layout-row",
+        "rows": [
+          {
+            "description": "",
+            "dataScript": "",
+            "type": "widget"
+          }
+        ]
       }
     ],
     "type": "layout-row"

--- a/typescript/packages/nextjs/src/components/ViewDashboard.tsx
+++ b/typescript/packages/nextjs/src/components/ViewDashboard.tsx
@@ -7,6 +7,7 @@ import {
 import { EditOutlined, EyeOutlined, LeftOutlined } from "@ant-design/icons";
 import { Button, Flex } from "antd";
 import type { Block as BlockType } from "api";
+import { useState } from "react";
 import styles from "./ViewDashboard.module.scss";
 import { DashboardName } from "./edit/DashboardName";
 import { EditBlock } from "./layout/EditBlock";
@@ -14,6 +15,8 @@ import { ViewBlock } from "./layout/ViewBlock";
 
 export const ViewDashboard = () => {
 	const dispatch = useAppDispatch();
+
+	const [displayKey, setDisplayKey] = useState(0);
 
 	const { viewingDashboard } = useAppSelector((s) => s.dashboard);
 	const { displayState } = useAppSelector((s) => s.dashboard);
@@ -41,6 +44,8 @@ export const ViewDashboard = () => {
 
 		dispatch(setViewingDashboard(updatedDashboard));
 		await configService.updateConfig(updatedDashboard);
+
+		setDisplayKey((prev) => prev + 1);
 	};
 
 	return (
@@ -75,6 +80,7 @@ export const ViewDashboard = () => {
 				<EditBlock
 					block={viewingDashboard.file.entryBlock}
 					isRoot
+					key={displayKey}
 					onUpdate={updateDashboard}
 				/>
 			) : (

--- a/typescript/packages/nextjs/src/components/general/Resizer.tsx
+++ b/typescript/packages/nextjs/src/components/general/Resizer.tsx
@@ -1,0 +1,28 @@
+import { Flex } from "antd";
+import { useEffect, useRef, useState } from "react";
+
+export const Resizer = ({ children }: { children: (props: { width: number; height: number }) => React.ReactElement }) => {
+    const container = useRef<HTMLDivElement>(null);
+    const [hasMounted, setHasMounted] = useState(false);
+
+    useEffect(() => {
+        setHasMounted(true);
+    }, []);
+
+    const maybeRenderContent = () => {
+        if (!hasMounted || container.current == null) {
+            return <div />;
+        }
+
+        return children({
+            width: container.current.clientWidth,
+            height: container.current.clientHeight,
+        });
+    }
+
+    return (
+        <Flex flex={1} ref={container}>
+            {maybeRenderContent()}
+        </Flex>
+    )
+}

--- a/typescript/packages/nextjs/src/components/layout/ViewBlock.tsx
+++ b/typescript/packages/nextjs/src/components/layout/ViewBlock.tsx
@@ -1,4 +1,5 @@
 import type { Block } from "api";
+import SyntaxHighlighter from "react-syntax-highlighter";
 import styles from "./ViewBlock.module.scss";
 
 export const ViewBlock = ({ block }: { block: Block }) => {
@@ -22,5 +23,5 @@ export const ViewBlock = ({ block }: { block: Block }) => {
 		);
 	}
 
-	return <div className={styles.widget}>Widget here</div>;
+	return <div className={styles.widget}><SyntaxHighlighter language="python">{block.dataScript}</SyntaxHighlighter></div>;
 };

--- a/typescript/packages/nextjs/src/components/widget/EditWidget.tsx
+++ b/typescript/packages/nextjs/src/components/widget/EditWidget.tsx
@@ -1,9 +1,7 @@
 import { useValidatePython } from "@/lib/hooks/useValidatePython";
-import { configService } from "@/lib/services/configService";
 import {
 	CheckCircleOutlined,
 	CloseCircleOutlined,
-	DeleteOutlined,
 	UndoOutlined,
 } from "@ant-design/icons";
 import { python } from "@codemirror/lang-python";
@@ -11,20 +9,15 @@ import { python } from "@codemirror/lang-python";
 import CodeMirror from "@uiw/react-codemirror";
 import { Button, Flex, Input, Spin, Tooltip } from "antd";
 import type { WidgetBlock } from "api";
-import { useRef } from "react";
+import { Resizer } from "../general/Resizer";
 import styles from "./EditWidget.module.scss";
 
 export const EditWidget = ({
 	widget,
 	onUpdate,
 }: { widget: WidgetBlock; onUpdate: (newWidget: WidgetBlock) => void }) => {
-	const codeContainer = useRef<HTMLDivElement>(null);
-
 	const { localCopy, setLocalCopy, isValid, canDiscard, onReset } =
 		useValidatePython(widget.dataScript);
-
-	const codeHeight = `${codeContainer.current?.clientHeight}px`;
-	const codeWidth = `${(codeContainer.current?.clientWidth ?? 0) * 0.99}px`;
 
 	const onSave = () => {
 		onUpdate({ ...widget, dataScript: localCopy });
@@ -40,6 +33,10 @@ export const EditWidget = ({
 	};
 
 	const renderCurrentStatus = () => {
+		if (localCopy === "") {
+			return;
+		}
+
 		if (isValid === undefined) {
 			return <Spin />;
 		}
@@ -74,26 +71,24 @@ export const EditWidget = ({
 						)}
 					</Flex>
 				</Flex>
-				<Flex
-					onKeyDown={checkForSave}
-					ref={codeContainer}
-					className={styles.codeEditor}
-					flex={1}
-				>
-					<CodeMirror
-						autoFocus
-						editable
-						height={codeHeight}
-						width={codeWidth}
-						value={localCopy}
-						key={codeContainer.current == null ? "null" : "not-null"}
-						extensions={[python()]}
-						onChange={setLocalCopy}
-						basicSetup={{
-							lineNumbers: true,
-							tabSize: 4,
-						}}
-					/>
+				<Flex onKeyDown={checkForSave} className={styles.codeEditor} flex={1}>
+					<Resizer>
+						{({ width, height }) => (
+							<CodeMirror
+								autoFocus
+								editable
+								height={`${height}px`}
+								width={`${width - 5}px`}
+								value={localCopy}
+								extensions={[python()]}
+								onChange={setLocalCopy}
+								basicSetup={{
+									lineNumbers: true,
+									tabSize: 4,
+								}}
+							/>
+						)}
+					</Resizer>
 				</Flex>
 			</Flex>
 		</Flex>

--- a/typescript/packages/nextjs/src/lib/hooks/useValidatePython.ts
+++ b/typescript/packages/nextjs/src/lib/hooks/useValidatePython.ts
@@ -37,6 +37,10 @@ export function useValidatePython(startingCode: string) {
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
 	useEffect(() => {
+		if (localCopy === "") {
+			return;
+		}
+
 		debouncedCheckPython(localCopy, maybeSetIsValid);
 	}, [localCopy]);
 


### PR DESCRIPTION
This pull request includes several improvements and feature additions to the `typescript/packages/nextjs` and `typescript/packages/nestjs` projects. The changes focus on enhancing the dashboard configuration, improving the `ViewDashboard` component, adding a new `Resizer` component, and refining the `EditWidget` component.

Dashboard configuration updates:
* Added `dataScript` fields to widgets in `Example.1.0.0.json` and `Some interesting dashboard here.1.0.0.json` to include a script that returns 1+1. [[1]](diffhunk://#diff-0a5309ed52d100241b04cc10dd4125eb3a9799310890854b81868780ff7ed897L9-R15) [[2]](diffhunk://#diff-e5a4cf3a4f51b9f193d92276dcccc1c95d265554cbf33872ae66a887a4da6b0aR8-R27)
* Added new layout rows with empty widgets to `Some interesting dashboard here.1.0.0.json`.

`ViewDashboard` component improvements:
* Imported `useState` and added `displayKey` state to force re-rendering of `EditBlock` when the dashboard is updated. [[1]](diffhunk://#diff-674497f1ed63332fab7cf0fb192486f0d7d8fbaa63df795ee2139cb66f6aab39R10) [[2]](diffhunk://#diff-674497f1ed63332fab7cf0fb192486f0d7d8fbaa63df795ee2139cb66f6aab39R19-R20) [[3]](diffhunk://#diff-674497f1ed63332fab7cf0fb192486f0d7d8fbaa63df795ee2139cb66f6aab39R47-R48) [[4]](diffhunk://#diff-674497f1ed63332fab7cf0fb192486f0d7d8fbaa63df795ee2139cb66f6aab39R83)

New `Resizer` component:
* Created a `Resizer` component to dynamically adjust the size of its children based on the container's dimensions.

`EditWidget` component refinements:
* Integrated the new `Resizer` component to handle the resizing of the `CodeMirror` editor. [[1]](diffhunk://#diff-55ad430d4dfe9335d74c8aafca5c736d19340ce7833045ef109834c77a06865dL2-L28) [[2]](diffhunk://#diff-55ad430d4dfe9335d74c8aafca5c736d19340ce7833045ef109834c77a06865dR36-R39) [[3]](diffhunk://#diff-55ad430d4dfe9335d74c8aafca5c736d19340ce7833045ef109834c77a06865dL77-R91)
* Added a check to skip validation if the `localCopy` is empty in the `useValidatePython` hook.

Other minor updates:
* Added `SyntaxHighlighter` to the `ViewBlock` component to render Python code within widgets. [[1]](diffhunk://#diff-af720581a9f930d99c589db65db8e292333126e6596c6627fe891aa0d7a4d97eR2) [[2]](diffhunk://#diff-af720581a9f930d99c589db65db8e292333126e6596c6627fe891aa0d7a4d97eL25-R26)