### PR TITLE
Stop debouncing

### DIFF
--- a/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
+++ b/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
@@ -2,17 +2,27 @@
   "entryBlock": {
     "rows": [
       {
-        "type": "widget",
-        "dataScript": "print(\"Hello world!!!!!\")\nreturn 1+1",
-        "description": "Example widget description"
-      },
-      {
-        "type": "layout-row",
-        "rows": [
+        "type": "layout-column",
+        "columns": [
           {
-            "description": "",
-            "dataScript": "",
-            "type": "widget"
+            "type": "layout-column",
+            "columns": [
+              {
+                "description": "",
+                "dataScript": "return 1+1",
+                "type": "widget"
+              }
+            ]
+          },
+          {
+            "type": "layout-column",
+            "columns": [
+              {
+                "description": "",
+                "dataScript": "return 1+1",
+                "type": "widget"
+              }
+            ]
           }
         ]
       },
@@ -21,7 +31,7 @@
         "rows": [
           {
             "description": "",
-            "dataScript": "",
+            "dataScript": "return 1+1",
             "type": "widget"
           }
         ]

--- a/typescript/packages/nextjs/src/lib/hooks/useValidatePython.ts
+++ b/typescript/packages/nextjs/src/lib/hooks/useValidatePython.ts
@@ -1,20 +1,6 @@
 import type { InvalidPythonCode, ValidPythonCode } from "api";
-import { debounce } from "lodash-es";
 import { useEffect, useState } from "react";
 import { configService } from "../services/configService";
-
-const checkPythonCode = async (
-	code: string,
-	setIsValid: (
-		code: string,
-		valid: ValidPythonCode | InvalidPythonCode,
-	) => void,
-) => {
-	const result = await configService.checkValidPythonCode(code);
-	setIsValid(code, result);
-};
-
-const debouncedCheckPython = debounce(checkPythonCode, 100);
 
 export function useValidatePython(startingCode: string) {
 	const [localCopy, setLocalCopy] = useState(startingCode);
@@ -35,13 +21,24 @@ export function useValidatePython(startingCode: string) {
 		setIsValid(valid);
 	};
 
+	const checkPythonCode = async (
+		code: string,
+		setIsValid: (
+			code: string,
+			valid: ValidPythonCode | InvalidPythonCode,
+		) => void,
+	) => {
+		const result = await configService.checkValidPythonCode(code);
+		setIsValid(code, result);
+	};
+
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
 	useEffect(() => {
 		if (localCopy === "") {
 			return;
 		}
 
-		debouncedCheckPython(localCopy, maybeSetIsValid);
+		checkPythonCode(localCopy, maybeSetIsValid);
 	}, [localCopy]);
 
 	return {


### PR DESCRIPTION
This pull request includes changes to improve the layout configuration of a dashboard and refactor the `useValidatePython` hook by removing the debounce functionality. The most important changes are summarized below:

### Dashboard Layout Configuration:

* [`typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json`](diffhunk://#diff-e5a4cf3a4f51b9f193d92276dcccc1c95d265554cbf33872ae66a887a4da6b0aL5-R34): Modified the layout structure from a single widget to multiple nested layout columns, which allows for a more flexible and organized dashboard design.

### Refactoring `useValidatePython` Hook:

* [`typescript/packages/nextjs/src/lib/hooks/useValidatePython.ts`](diffhunk://#diff-c67355240f6e7bd464e07cdf838949f40fb7105e834f74d24cfde92890e2dcf4L2-L18): Removed the `debounce` import and the `debouncedCheckPython` function, and moved the `checkPythonCode` function inside the `useValidatePython` hook. This change simplifies the code and eliminates the debounce functionality. [[1]](diffhunk://#diff-c67355240f6e7bd464e07cdf838949f40fb7105e834f74d24cfde92890e2dcf4L2-L18) [[2]](diffhunk://#diff-c67355240f6e7bd464e07cdf838949f40fb7105e834f74d24cfde92890e2dcf4R24-R41)