### PR TITLE
Switch everything to iframes

### DIFF
--- a/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
+++ b/typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json
@@ -9,6 +9,11 @@
             "description": "",
             "dataScript": "",
             "type": "widget"
+          },
+          {
+            "description": "",
+            "dataScript": "",
+            "type": "widget"
           }
         ],
         "space": 2

--- a/typescript/packages/nextjs/src/components/layout/ViewBlock.module.scss
+++ b/typescript/packages/nextjs/src/components/layout/ViewBlock.module.scss
@@ -12,15 +12,3 @@
 .layoutColumns {
     @extend %block;
 }
-
-.widget {
-    @extend %block;
-
-    justify-content: center;
-    align-items: center;
-    border: 1px solid vars.$black;
-    border-radius: 6px;
-    margin: 10px;
-    background: vars.$white;
-    color: vars.$muted-text;
-}

--- a/typescript/packages/nextjs/src/components/layout/ViewBlock.tsx
+++ b/typescript/packages/nextjs/src/components/layout/ViewBlock.tsx
@@ -1,5 +1,5 @@
 import type { Block } from "api";
-import SyntaxHighlighter from "react-syntax-highlighter";
+import { ViewWidget } from "../widget/ViewWidget";
 import styles from "./ViewBlock.module.scss";
 
 export const ViewBlock = ({ block }: { block: Block }) => {
@@ -23,5 +23,5 @@ export const ViewBlock = ({ block }: { block: Block }) => {
 		);
 	}
 
-	return <div className={styles.widget} style={{ flex: block.space ?? 1 }}><SyntaxHighlighter language="python">{block.dataScript}</SyntaxHighlighter></div>;
+	return <ViewWidget widget={block} />;
 };

--- a/typescript/packages/nextjs/src/components/widget/ViewWidget.module.scss
+++ b/typescript/packages/nextjs/src/components/widget/ViewWidget.module.scss
@@ -1,0 +1,18 @@
+@use "@/style/variables" as vars;
+
+.widget {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    border: 1px solid vars.$black;
+    border-radius: 6px;
+    margin: 10px;
+    background: vars.$white;
+    color: vars.$muted-text;
+    padding: 2px 1px;
+    overflow: hidden;
+
+    > iframe {
+        border-radius: 6px;
+    }
+}

--- a/typescript/packages/nextjs/src/components/widget/ViewWidget.tsx
+++ b/typescript/packages/nextjs/src/components/widget/ViewWidget.tsx
@@ -1,0 +1,38 @@
+import type { WidgetBlock } from "api";
+import { useEffect, useRef } from "react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import styles from "./ViewWidget.module.scss";
+
+/* <SyntaxHighlighter language="python">
+    {widget.dataScript}
+</SyntaxHighlighter> */
+
+export const ViewWidget = ({ widget }: { widget: WidgetBlock }) => {
+	const iframeRef = useRef<HTMLIFrameElement>(null);
+
+    // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+    useEffect(() => {
+        if (iframeRef.current == null || iframeRef.current.contentWindow == null) {
+            return;
+        }
+
+        console.log(iframeRef.current.contentWindow.scrollBy);
+        iframeRef.current.contentWindow?.scrollBy({ top: 1000 });
+    }, [iframeRef.current])
+
+	return (
+		<div className={styles.widget} style={{ flex: widget.space ?? 1 }}>
+			<iframe
+				title="amzn"
+				src="https://www.google.com/maps/embed/v1/place?key=AIzaSyC6uWRmJgoYd5wx-198bfnO41WblQ5HHig&q=Ch%C4%ABsai%20Sushi%20Club%2C3369%20Mission%20Street%2CSan%20Francisco%2CCA%2C94110"
+				style={{
+					display: "flex",
+					flex: 1,
+					height: "100%",
+					width: "100%",
+				}}
+                ref={iframeRef}
+			/>
+		</div>
+	);
+};


### PR DESCRIPTION
This pull request introduces several changes to the `ViewBlock` and `ViewWidget` components in the `typescript/packages/nextjs` directory. The primary focus is on refactoring the `ViewBlock` component to use a new `ViewWidget` component and moving related styles to a new stylesheet. Additionally, a new widget layout is added to the dashboard configuration.

Refactoring and component updates:

* [`typescript/packages/nextjs/src/components/layout/ViewBlock.tsx`](diffhunk://#diff-af720581a9f930d99c589db65db8e292333126e6596c6627fe891aa0d7a4d97eL2-R2): Replaced the `SyntaxHighlighter` component with the new `ViewWidget` component. [[1]](diffhunk://#diff-af720581a9f930d99c589db65db8e292333126e6596c6627fe891aa0d7a4d97eL2-R2) [[2]](diffhunk://#diff-af720581a9f930d99c589db65db8e292333126e6596c6627fe891aa0d7a4d97eL26-R26)
* [`typescript/packages/nextjs/src/components/widget/ViewWidget.tsx`](diffhunk://#diff-7b43d5c9a4cfdcac6e03df6e5c60e4aa2981497750e0cbf49d9f44885a1a47f5R1-R38): Added the new `ViewWidget` component, which includes an iframe and an effect to scroll the iframe content.

Stylesheet changes:

* [`typescript/packages/nextjs/src/components/layout/ViewBlock.module.scss`](diffhunk://#diff-8ccc5e98664ae17a1ae25872025f2438d860d9aa4993a0698e1f9a178ab010ccL15-L26): Removed the `.widget` styles as they are now part of the `ViewWidget` component.
* [`typescript/packages/nextjs/src/components/widget/ViewWidget.module.scss`](diffhunk://#diff-34206a2ded18acfeefaa9ea3a94c0495cd9d8508bd6acece2f066dbfaa638b6aR1-R18): Added the new stylesheet for the `ViewWidget` component, including styles for the iframe.

Dashboard configuration:

* [`typescript/packages/nestjs/.search-and-discovery/config/Some interesting dashboard here.1.0.0.json`](diffhunk://#diff-e5a4cf3a4f51b9f193d92276dcccc1c95d265554cbf33872ae66a887a4da6b0aR8-R12): Added a new widget layout to the dashboard configuration.