### PR TITLE
Add service to typescript

### DIFF
--- a/python/browser-agent/.gitignore
+++ b/python/browser-agent/.gitignore
@@ -1,1 +1,2 @@
 logs/*
+command_runner.log

--- a/typescript/packages/nextjs/src/lib/services/browserAgentService.ts
+++ b/typescript/packages/nextjs/src/lib/services/browserAgentService.ts
@@ -1,0 +1,81 @@
+export interface CreateSession {
+    session_id: string;
+}
+
+export interface CommandResponse {
+    result: unknown;
+}
+
+export interface StopClientResponse {
+    success: boolean;
+}
+
+export interface SessionLogs {
+    logs: string;
+}
+
+class BrowserAgentService {
+    public async createNewSession() {
+        const rawResponse = await fetch("http://localhost:500/create-session", {
+			headers: {
+				"Content-Type": "application/json",
+			},
+		});
+		const sessionId = await rawResponse.json();
+        return sessionId as CreateSession;
+    }
+
+    public async startClient(sessionId: string, startingPage?: string) {
+        const rawResponse = await fetch("http://localhost:500/start-client", {
+            method: "POST",
+            headers: {
+				"Content-Type": "application/json",
+			},
+            body: JSON.stringify({ session_id: sessionId, starting_page: startingPage }),
+        });
+        const response = await rawResponse.json();
+        return response as CommandResponse;
+    }
+
+    public async runCode(sessionId: string, code: string) {
+        const rawResponse = await fetch("http://localhost:500/run-code", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ session_id: sessionId, code }),
+        });
+        const response = await rawResponse.json();
+        return response as CommandResponse;
+    }
+
+    public async getSessionLogs(sessionId: string) {
+        const rawResponse = await fetch("http://localhost:500/get-session-logs", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ session_id: sessionId }),
+        });
+        const response = await rawResponse.json();
+        return response as SessionLogs;
+    }
+
+    public async streamSession(sessionId: string) {
+        return `http://localhost:500/session/${sessionId}/stream.mjpeg`;
+    }
+
+    public async stopClient(sessionId: string) {
+        const rawResponse = await fetch("http://localhost:500/end-session", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ session_id: sessionId }),
+        });
+        const response = await rawResponse.json();
+        return response as StopClientResponse;
+    }
+}
+
+export const browserAgentService = new BrowserAgentService();


### PR DESCRIPTION
This pull request includes several changes to the `python/browser-agent` and `typescript/packages/nextjs` directories. The changes focus on refactoring API endpoints and adding a new service in TypeScript to interact with these endpoints.

### Refactoring API Endpoints:

* [`python/browser-agent/src/api/endpoints.py`](diffhunk://#diff-1441569138173f6548e0dc64611e9508d90dede072d1d1621f59bce74511b11cL6-R9): Reordered and modified existing endpoints for better organization and functionality. The `create-session` and `run-code` endpoints were swapped in their positions, and the `list-sessions` and `end-session` endpoints were moved to the end of the file. [[1]](diffhunk://#diff-1441569138173f6548e0dc64611e9508d90dede072d1d1621f59bce74511b11cL6-R9) [[2]](diffhunk://#diff-1441569138173f6548e0dc64611e9508d90dede072d1d1621f59bce74511b11cL43-R46) [[3]](diffhunk://#diff-1441569138173f6548e0dc64611e9508d90dede072d1d1621f59bce74511b11cL65-L83) [[4]](diffhunk://#diff-1441569138173f6548e0dc64611e9508d90dede072d1d1621f59bce74511b11cR79-R97)

### Adding TypeScript Service:

* [`typescript/packages/nextjs/src/lib/services/browserAgentService.ts`](diffhunk://#diff-682c4404a6abc99f139d2e416e21dfa6ae2554f8372a4f33e1e31644fe0027efR1-R81): Added a new `BrowserAgentService` class to interact with the browser agent API. This includes methods for creating a new session, starting a client, running code, retrieving session logs, streaming a session, and stopping a client.

### Other Changes:

* [`python/browser-agent/.gitignore`](diffhunk://#diff-c80284cb3373ce3d2cc3815295d81d2c51f374dbf0ac84edc268db1bcc411af1R2): Added `command_runner.log` to the `.gitignore` file to ignore log files generated by the command runner.